### PR TITLE
Visualize endpoints differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-tbd
+- Vizualize FastAPI endpoints differently from other dependencies to make them stand out in the graph.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ A sample graph for the application in [fastapi_di_viz/sample](./fastapi_di_viz/s
 title: FastAPI dependency chain
 ---
 graph TD;
+    root([root])
+    a([a])
+    b([b])
     root --> get_settings
     a --> get_serviceA
     get_serviceA --> get_repo

--- a/fastapi_di_viz/utils.py
+++ b/fastapi_di_viz/utils.py
@@ -52,27 +52,31 @@ def build_dependency_graph(app: FastAPI) -> Digraph:
     dot = Digraph(comment="FastAPI Dependency Graph")
 
     visited: Set[Callable] = set()
-    stack: List[Tuple[Callable, Type]] = []
+    stack: List[Tuple[Callable, Type, bool]] = []
 
-    def visit(callable: Callable, _parent: Optional[Callable] = None):
+    def visit(callable: Callable, parent: Optional[Callable] = None):
         if callable in visited:
             return
         visited.add(callable)
 
         dependencies = get_dependencies(callable)
+        is_leaf = parent is None
         for dep in dependencies:
-            stack.append((callable, dep))
+            stack.append((callable, dep, is_leaf))
             visit(dep, callable)
 
     for route in app.routes:
         if isinstance(route, APIRoute):
             visit(route.endpoint)
 
-    for parent, child in stack:
+    for parent, child, is_leaf in stack:
         # Use the name of the callable if available, otherwise use the class name.
         # This is useful for lambdas and other callables without a __name__ attribute.
         child_name = getattr(child, "__name__", child.__class__.__name__)
-        dot.node(parent.__name__)
+        if is_leaf:
+            dot.node(parent.__name__, None, shape="rounded")
+        else:
+            dot.node(parent.__name__, None)
         dot.node(child_name)
         dot.edge(parent.__name__, child_name)
 
@@ -86,6 +90,15 @@ def mermaid_from_dot(dot: Digraph) -> str:
     mermaid = "---\ntitle: FastAPI dependency chain\n---\n"
     mermaid += "graph TD;\n"
     for node in dot.body:
+        shape = None
+        if "shape" in node:
+            # node content, e.g., `root [shape=rounded]`
+            name = node.split("[")[0].strip()
+            shape = node.split("=")[1].split("]")[0]
+            if shape == "rounded":
+                mermaid += f"    {name}([{name}])\n"
+            else:
+                mermaid += f"    {name}({name})\n"
         if "label" in node:
             name = node.split("[")[0].strip()
             label = node.split("[")[1].split("]")[0]

--- a/tests/snapshots/test_utils/test_build_dependency_graph_sample_app/build_dependency_graph_sample_app
+++ b/tests/snapshots/test_utils/test_build_dependency_graph_sample_app/build_dependency_graph_sample_app
@@ -1,9 +1,9 @@
 // FastAPI Dependency Graph
 digraph {
-	root
+	root [shape=rounded]
 	get_settings
 	root -> get_settings
-	a
+	a [shape=rounded]
 	get_serviceA
 	a -> get_serviceA
 	get_serviceA
@@ -12,7 +12,7 @@ digraph {
 	get_serviceA
 	get_settings
 	get_serviceA -> get_settings
-	b
+	b [shape=rounded]
 	get_serviceB
 	b -> get_serviceB
 	get_serviceB

--- a/tests/snapshots/test_utils/test_build_dependency_graph_single_route/build_dependency_graph_single_route
+++ b/tests/snapshots/test_utils/test_build_dependency_graph_single_route/build_dependency_graph_single_route
@@ -1,12 +1,12 @@
 // FastAPI Dependency Graph
 digraph {
-	home
+	home [shape=rounded]
 	get_service
 	home -> get_service
 	get_service
 	get_settings
 	get_service -> get_settings
-	home
+	home [shape=rounded]
 	get_settings
 	home -> get_settings
 }

--- a/tests/snapshots/test_utils/test_build_dependency_graph_with_security/build_dependency_graph_with_security
+++ b/tests/snapshots/test_utils/test_build_dependency_graph_with_security/build_dependency_graph_with_security
@@ -1,6 +1,6 @@
 // FastAPI Dependency Graph
 digraph {
-	home
+	home [shape=rounded]
 	HTTPBearer
 	home -> HTTPBearer
 }

--- a/tests/snapshots/test_utils/test_mermaid_from_dot_sample_app/mermaid_from_dot_sample_app
+++ b/tests/snapshots/test_utils/test_mermaid_from_dot_sample_app/mermaid_from_dot_sample_app
@@ -2,6 +2,9 @@
 title: FastAPI dependency chain
 ---
 graph TD;
+    root([root])
+    a([a])
+    b([b])
     root --> get_settings
     a --> get_serviceA
     get_serviceA --> get_repo


### PR DESCRIPTION
This PR adds code to render endpoints differently than other dependencies. Since endpoints are entrypoints to the graph, it's much easier to see them in a more complex chart when they have a different shape.